### PR TITLE
Enforce mandatory capture for matching face cards

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -96,6 +96,8 @@ export default function GamePage({ params }: { params: { id: string } }) {
   const table: Card[] = game?.table || [];
   const turnPlayer = game?.players?.[game?.turn];
   const isMyTurn = turnPlayer?.id === playerId;
+  const handCard = selected !== null ? hand[selected] : null;
+  const canDiscard = !(handCard && handCard.rank > 10 && table.some((c) => c.rank === handCard.rank));
 
   useEffect(() => {
     if (!isMyTurn) {
@@ -145,11 +147,10 @@ export default function GamePage({ params }: { params: { id: string } }) {
           onSelect={setSelected}
           disabled={!isMyTurn}
         />
-        {isMyTurn && selected !== null && (
+        {isMyTurn && selected !== null && handCard && (
           <div className="bg-white text-black p-2 rounded mt-2">
             <div className="font-bold">Legal moves</div>
             {moves.map((m, i) => {
-              const handCard = hand[selected];
               const multiGroup = m.groups.length > 1;
               const prefix =
                 handCard.rank <= 10 && multiGroup ? (
@@ -190,9 +191,11 @@ export default function GamePage({ params }: { params: { id: string } }) {
                 </button>
               );
             })}
-            <button onClick={() => play()} className="block w-full text-left">
-              Discard
-            </button>
+            {canDiscard && (
+              <button onClick={() => play()} className="block w-full text-left">
+                Discard
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/pages/api/play.ts
+++ b/pages/api/play.ts
@@ -34,6 +34,10 @@ export default async function handler(
     res.status(400).json({ error: 'Card not in hand' });
     return;
   }
+  if (!capture && card.rank > 10 && game.table.some((c: Card) => c.rank === card.rank)) {
+    res.status(400).json({ error: 'Must capture matching face card' });
+    return;
+  }
   hand.splice(cardIndex, 1);
   let table: Card[] = game.table;
   if (capture) {


### PR DESCRIPTION
## Summary
- Prevent discarding a face card when an identical rank is on the table
- Hide discard option in the UI when such a capture is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7a1e707548331a12a58824e3282d0