### PR TITLE
Fix red suit coloring for hearts and diamonds

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -28,16 +28,16 @@ const isSpecial = (c: Card) =>
 function cardNode(c: Card): JSX.Element {
   const base = rankSymbols[c.rank] || c.rank.toString();
   const isRed = c.suit === 'hearts' || c.suit === 'diamonds';
-  const color = isRed ? 'text-red-600' : 'text-black';
-  if (isSpecial(c)) {
-    return (
-      <span className={color}>
-        {base}
-        {suitSymbols[c.suit]}
-      </span>
-    );
-  }
-  return <span className={color}>{base}</span>;
+  const valueStyle = { color: isRed ? '#991b1b' : '#000' };
+  const pipStyle = { color: isRed ? '#dc2626' : '#000' };
+  return (
+    <span>
+      <span style={valueStyle}>{base}</span>
+      {isSpecial(c) && (
+        <span style={pipStyle}>{suitSymbols[c.suit]}</span>
+      )}
+    </span>
+  );
 }
 
 export default function GamePage({ params }: { params: { id: string } }) {
@@ -154,11 +154,12 @@ export default function GamePage({ params }: { params: { id: string } }) {
               const prefix =
                 handCard.rank <= 10 && multiGroup ? (
                   <span
-                    className={
-                      handCard.suit === 'hearts' || handCard.suit === 'diamonds'
-                        ? 'text-red-600'
-                        : 'text-black'
-                    }
+                    style={{
+                      color:
+                        handCard.suit === 'hearts' || handCard.suit === 'diamonds'
+                          ? '#991b1b'
+                          : '#000',
+                    }}
                   >
                     {rankSymbols[handCard.rank] || handCard.rank}s:{' '}
                   </span>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -35,19 +35,20 @@ export default function CardView({
     'w-16 h-12 border rounded flex flex-row items-center justify-center m-1 gap-1';
   const variantClass =
     variant === 'hand' ? 'bg-white shadow-md' : 'bg-gray-100';
-  const colorClass = isRed ? 'text-red-600' : 'text-black';
+  const valueStyle = { color: isRed ? '#991b1b' : '#000' };
+  const pipStyle = { color: isRed ? '#dc2626' : '#000' };
   const interactivity = disabled
     ? 'opacity-50 pointer-events-none'
     : 'cursor-pointer';
   return (
     <div
       onClick={!disabled ? onClick : undefined}
-      className={`${base} ${variantClass} ${colorClass} ${
+      className={`${base} ${variantClass} ${
         selected ? 'ring-4 ring-yellow-400' : ''
       } ${interactivity}`}
     >
-      <span>{label}</span>
-      <span>{suitSymbols[card.suit]}</span>
+      <span style={valueStyle}>{label}</span>
+      <span style={pipStyle}>{suitSymbols[card.suit]}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use inline styles to color hearts and diamonds red in card component
- apply inline red coloring in legal move display

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7a2332ed4833192f49c689723f8b0